### PR TITLE
[drud/general#14] Add build-tools to proxy repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+
+# Temporary build-tools artifacts to be ignored
+.go/
+bin/
+.container*
+.push*
+linux
+darwin
+.dockerfile
+VERSION.txt
+.docker_image

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,6 +1,5 @@
-FROM jwilder/nginx-proxy:0.4.0
+FROM UPSTREAM_REPO
 
-FROM jwilder/nginx-proxy
 RUN { \
       echo 'client_max_body_size 100m;'; \
     } > /etc/nginx/conf.d/drud.conf

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,39 @@
-TAG = $(shell git rev-parse --abbrev-ref HEAD | tr -d '\n')
-PREFIX = drud/nginx-proxy
+# Makefile for a standard repo with associated container
 
-dev:
-	docker build -t $(PREFIX):$(TAG) .
+##### These variables need to be adjusted in most repositories #####
 
-latest: dev
-	docker tag $(PREFIX):$(TAG) $(PREFIX):latest
+# This repo's root import path (under GOPATH).
+#PKG := github.com/drud/repo_name
 
-canary: dev
-	docker push $(PREFIX):$(TAG)
+# Docker repo for a push
+DOCKER_REPO ?= drud/nginx-proxy
 
-all: latest canary
-	docker push $(PREFIX):latest
+# Upstream repo used in the Dockerfile
+UPSTREAM_REPO ?= jwilder/nginx-proxy:0.4.0
+
+# Top-level directories to build
+#SRC_DIRS := files drudapi secrets utils
+
+
+# VERSION can be set by
+  # Default: git tag
+  # make command line: make VERSION=0.9.0
+# It can also be explicitly set in the Makefile as commented out below.
+
+# This version-strategy uses git tags to set the version string
+# VERSION can be overridden on make commandline: make VERSION=0.9.1 push
+VERSION := $(shell git describe --tags --always --dirty)
+#
+# This version-strategy uses a manual value to set the version string
+#VERSION := 1.2.3
+
+# Each section of the Makefile is included from standard components below.
+# If you need to override one, import its contents below and comment out the
+# include. That way the base components can easily be updated as our general needs
+# change.
+#include build-tools/makefile_components/base_build_go.mak
+include build-tools/makefile_components/base_build_python-docker.mak
+include build-tools/makefile_components/base_container.mak
+include build-tools/makefile_components/base_push.mak
+#include build-tools/makefile_components/base_test_go.mak
+include build-tools/makefile_components/base_test_python.mak

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+## Information
+
+This project is based on the [jwilder/nginx-proxy](http;//github.com/jwilder/nginx-proxy) project and contains DRUD specific overrides to the nginx config template. If you are looking for a generalized docker router solution, we recommend you look there.
+
+## Usage
+
+This container is used to allow all `drud dev` sites to exist side by side on a shared port (typically 80). It serves as a proxy to those sites, and forwards traffic to the appropriate dev site depending on the hostname used.

--- a/build-tools/Makefile.example
+++ b/build-tools/Makefile.example
@@ -1,0 +1,41 @@
+# Makefile for a standard repo with associated container
+
+##### These variables need to be adjusted in most repositories #####
+
+# This repo's root import path (under GOPATH).
+PKG := github.com/drud/repo_name
+
+# Docker repo for a push
+# DOCKER_REPO ?= drud/docker_repo_name
+
+# Upstream repo used in the Dockerfile
+# UPSTREAM_REPO ?= full/upstream-docker-repo
+
+# Top-level directories to build
+SRC_DIRS := files drudapi secrets utils
+
+# Optional to docker build
+# DOCKER_ARGS =
+
+# VERSION can be set by
+  # Default: git tag
+  # make command line: make VERSION=0.9.0
+# It can also be explicitly set in the Makefile as commented out below.
+
+# This version-strategy uses git tags to set the version string
+# VERSION can be overridden on make commandline: make VERSION=0.9.1 push
+VERSION := $(shell git describe --tags --always --dirty)
+#
+# This version-strategy uses a manual value to set the version string
+#VERSION := 1.2.3
+
+# Each section of the Makefile is included from standard components below.
+# If you need to override one, import its contents below and comment out the
+# include. That way the base components can easily be updated as our general needs
+# change.
+include build-tools/makefile_components/base_build_go.mak
+#include build-tools/makefile_components/base_build_python-docker.mak
+include build-tools/makefile_components/base_container.mak
+include build-tools/makefile_components/base_push.mak
+include build-tools/makefile_components/base_test_go.mak
+#include build-tools/makefile_components/base_test_python.mak

--- a/build-tools/README.md
+++ b/build-tools/README.md
@@ -1,0 +1,49 @@
+# Build tools for standard makefile
+
+**These build tools live at https://github.com/drud/build-tools**. If you are viewing this README in any other repository, it's important to know that modifications should **never** be made directly, and instead should be made to the base repository and pulled in via the subtree merge instructions below.
+
+These tools add standard components (sub-makefiles and build scripts) as well as example starters for the Makefile and circle.yml.
+
+## Add build-tools to a Makefile
+
+```
+git remote add -f build-tools git@github.com:drud/build-tools.git
+git merge -s ours --allow-unrelated-histories build-tools/master
+git read-tree --prefix=build-tools -u build-tools/master
+git commit -m "Added build-tools for standard makefile as subtree"
+```
+
+## Update build-tools directory from this repository using subtree merge
+
+```
+# If there is not a build-tools remote, add it
+git remote add -f build-tools git@github.com:drud/build-tools.git
+# Fetch/merge current build-tools (pull doesn't work if set to branch.autosetuprebase=always)
+git fetch build-tools
+git merge -s subtree build-tools/master
+```
+
+## Set up a Makefile to begin with
+
+* Copy the Makefile.example to "Makefile" in the root of your project
+* Edit the sub-Makefiles included
+* Update the variables at the top of the Makefile
+
+## Additional chores when installing:
+
+* Add the items from gitignore_example to your .gitignore
+* Update the project README.md to explain how to build - the target reminders in the paragraph below may be helpful.
+
+## Basic targets and capabilities
+
+Using this base will allow you to build with standard targets like build, test, container, push, clean:
+
+```
+make 
+make test
+make container
+make push
+make VERSION=0.3.0 container
+make VERSION=0.3.0 push
+make clean
+```

--- a/build-tools/build-scripts/build_go.sh
+++ b/build-tools/build-scripts/build_go.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+#
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${PKG}" ]; then
+    echo "PKG must be set"
+    exit 1
+fi
+if [ -z "${OS}" ]; then
+    echo "OS must be set"
+    exit 1
+fi
+if [ -z "${VERSION}" ]; then
+    echo "VERSION must be set"
+    exit 1
+fi
+
+export CGO_ENABLED=0
+export GOOS="${OS}"
+
+TARGETS=$(for d in "$@"; do echo ./$d/...; done)
+
+go install                                                     \
+    -installsuffix "static"                                        \
+    -ldflags "-X ${PKG}/pkg/version.VERSION=${VERSION}"            \
+    $TARGETS

--- a/build-tools/build-scripts/test_go.sh
+++ b/build-tools/build-scripts/test_go.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+#
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if [ -z "${OS}" ]; then
+    echo "OS must be set"
+    exit 1
+fi
+
+export CGO_ENABLED=0
+export GOOS="${OS}"
+
+TARGETS=$(for d in "$@"; do echo ./$d/...; done)
+
+echo "Running tests:"
+go test -i -installsuffix "static" ${TARGETS}
+go test -installsuffix "static" ${TARGETS}
+echo
+
+echo -n "Checking gofmt: "
+ERRS=$(find "$@" -type f -name \*.go | xargs gofmt -l 2>&1 || true)
+if [ -n "${ERRS}" ]; then
+    echo "FAIL - the following files need to be gofmt'ed:"
+    for e in ${ERRS}; do
+        echo "    $e"
+    done
+    echo
+    exit 1
+fi
+echo "PASS"
+echo
+
+echo -n "Checking go vet ${TARGETS}: "
+ERRS=$(go vet ${TARGETS} 2>&1 || true)
+if [ -n "${ERRS}" ]; then
+    echo "FAIL"
+    echo "${ERRS}"
+    echo
+    exit 1
+fi
+echo "PASS"
+echo

--- a/build-tools/circle.yml.example
+++ b/build-tools/circle.yml.example
@@ -1,0 +1,10 @@
+machine:
+    services:
+        - docker
+
+#dependencies:
+#    pre:
+
+test:
+    override:
+        - make test

--- a/build-tools/gitignore.example
+++ b/build-tools/gitignore.example
@@ -1,0 +1,12 @@
+# Add these lines to project .gitignore
+
+# Temporary build-tools artifacts to be ignored
+.go/
+bin/
+.container*
+.push*
+linux
+darwin
+.dockerfile
+VERSION.txt
+.docker_image

--- a/build-tools/makefile_components/README.md
+++ b/build-tools/makefile_components/README.md
@@ -1,0 +1,5 @@
+# Base Makefile components
+
+Please do not change these files. They're intended to be replaceable globally in all repositories as our needs changed.
+
+If one of these sections does not meet your needs, consider copying its contents into ../Makefile and commenting out the include and adding a comment about what you did and why.

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -1,0 +1,54 @@
+# Base Build portion of makefile
+##### PLEASE DO NOT CHANGE THIS FILE #####
+##### If one of these sections does not meet your needs, consider copying its
+##### contents into ../Makefile and commenting out the include and adding a
+##### comment about what you did and why.
+
+
+.PHONY: all build test push clean container-clean bin-clean version
+
+SHELL := /bin/bash
+
+GOFILES = $(shell find $(SRC_DIRS) -name "*.go")
+
+BUILD_IMAGE ?= golang:1.7-alpine
+
+BUILD_BASE_DIR ?= $$PWD
+
+build: linux darwin
+
+linux darwin: $(GOFILES)
+	@echo "building $@ from $(GOFILES)"
+	@rm -f VERSION.txt
+	@mkdir -p bin/$@
+	@docker run                                                            \
+	    -t                                                                \
+	    -u root:root                                             \
+	    -v $(BUILD_BASE_DIR)/build-tools:/build-tools		\
+	    -v $$(pwd)/.go:/go                                                 \
+	    -v $$(pwd):/go/src/$(PKG)                                          \
+	    -v $$(pwd)/bin/$@:/go/bin                                     \
+	    -v $$(pwd)/bin/$@:/go/bin/$@                      \
+	    -v $$(pwd)/.go/std/$@:/usr/local/go/pkg/$@_amd64_static  \
+	    -e GOOS=$@	\
+	    -w /go/src/$(PKG)                                                  \
+	    $(BUILD_IMAGE)                                                     \
+	    /bin/sh -c "                                                       \
+	        OS=$@                                                 \
+	        VERSION=$(VERSION)                                             \
+	        PKG=$(PKG)                                                     \
+	        /build-tools/build-scripts/build_go.sh $(SRC_DIRS)                                              \
+	    "
+	@touch $@
+	@echo $(VERSION) >VERSION.txt
+
+version:
+	@echo VERSION:$(VERSION)
+
+clean: container-clean bin-clean
+
+container-clean:
+	rm -rf .container-* .dockerfile* .push-* linux darwin container VERSION.txt .docker_image
+
+bin-clean:
+	rm -rf .go bin .tmp

--- a/build-tools/makefile_components/base_build_python-docker.mak
+++ b/build-tools/makefile_components/base_build_python-docker.mak
@@ -1,0 +1,33 @@
+# Base Build portion of makefile
+##### PLEASE DO NOT CHANGE THIS FILE #####
+##### If one of these sections does not meet your needs, consider copying its
+##### contents into ../Makefile and commenting out the include and adding a
+##### comment about what you did and why.
+
+
+.PHONY: all build test push clean container-clean bin-clean version
+
+SHELL := /bin/bash
+
+BUILD_IMAGE ?= golang:1.7-alpine
+
+all: VERSION.txt build
+
+build: linux
+
+linux:
+#	@echo "No code to build to build in "$@" - try 'make container'
+
+VERSION.txt:
+	@echo $(VERSION) >VERSION.txt
+
+version:
+	@echo VERSION:$(VERSION)
+
+clean: container-clean bin-clean
+
+container-clean:
+	rm -rf .container-* .dockerfile* .push-* linux darwin container VERSION.txt .docker_image
+
+bin-clean:
+	rm -rf .go bin

--- a/build-tools/makefile_components/base_container.mak
+++ b/build-tools/makefile_components/base_container.mak
@@ -1,0 +1,19 @@
+# Container section of standard makefile
+##### PLEASE DO NOT CHANGE THIS FILE #####
+##### If one of these sections does not meet your needs, consider copying its
+##### contents into ../Makefile and commenting out the include and adding a
+##### comment about what you did and why.
+
+
+DOTFILE_IMAGE = $(subst /,_,$(IMAGE))-$(VERSION)
+
+container: linux .container-$(DOTFILE_IMAGE) container-name
+
+.container-$(DOTFILE_IMAGE): linux Dockerfile.in
+	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
+	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
+	@docker images -q $(DOCKER_REPO):$(VERSION) > $@
+	@echo $(DOCKER_REPO):$(VERSION) >.docker_image
+
+container-name:
+	@echo "container: $(DOCKER_REPO):$(VERSION)"

--- a/build-tools/makefile_components/base_push.mak
+++ b/build-tools/makefile_components/base_push.mak
@@ -1,0 +1,13 @@
+# Push section of Makefile
+##### PLEASE DO NOT CHANGE THIS FILE #####
+##### If one of these sections does not meet your needs, consider copying its
+##### contents into ../Makefile and commenting out the include and adding a
+##### comment about what you did and why.
+
+push: .push-$(DOTFILE_IMAGE) push-name
+.push-$(DOTFILE_IMAGE): .container-$(DOTFILE_IMAGE)
+	@gcloud docker -- push $(DOCKER_REPO):$(VERSION)
+	@docker images -q $(DOCKER_REPO):$(VERSION) > $@
+
+push-name:
+	@echo "pushed: $(DOCKER_REPO):$(VERSION)"

--- a/build-tools/makefile_components/base_test_go.mak
+++ b/build-tools/makefile_components/base_test_go.mak
@@ -1,0 +1,24 @@
+# test section of Makefile
+##### PLEASE DO NOT CHANGE THIS FILE #####
+##### If one of these sections does not meet your needs, consider copying its
+##### contents into ../Makefile and commenting out the include and adding a
+##### comment about what you did and why.
+
+test: linux
+	@mkdir -p bin/linux
+	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
+	@docker run                                                            \
+	    -t                                                                \
+	    -u root:root                                             \
+		-v $(BUILD_BASE_DIR)/build-tools:/build-tools		\
+	    -v $$(pwd)/.go:/go                                                 \
+	    -v $$(pwd):/go/src/$(PKG)                                          \
+	    -v $$(pwd)/bin/linux:/go/bin                                     \
+	    -v $$(pwd)/.go/std/linux:/usr/local/go/pkg/linux_amd64_static  \
+	    -w /go/src/$(PKG)                                                  \
+	    -e GOOS=linux	\
+	    $(BUILD_IMAGE)                                                     \
+	    /bin/sh -c "                                                       \
+	        OS=linux                                                   \
+	        /build-tools/build-scripts/test_go.sh $(SRC_DIRS)                                    \
+	    "

--- a/build-tools/makefile_components/base_test_python.mak
+++ b/build-tools/makefile_components/base_test_python.mak
@@ -1,0 +1,8 @@
+# test section of Makefile
+##### PLEASE DO NOT CHANGE THIS FILE #####
+##### If one of these sections does not meet your needs, consider copying its
+##### contents into ../Makefile and commenting out the include and adding a
+##### comment about what you did and why.
+
+test: linux
+	@echo "No testing currently implemented"

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,10 @@
+machine:
+    services:
+        - docker
+
+test:
+    override:
+        - make container
+        - docker run -p 80:80 --name=nginx-proxy -v /var/run/docker.sock:/tmp/docker.sock:ro -d $(cat .docker_image)
+        - curl -I localhost | grep 503  # Make sure we get a 503 from nginx by default
+        - docker stop nginx-proxy


### PR DESCRIPTION
This repository needs to get tagged with a 0.1.0 release, so as a part of that I went ahead and added the build-tools to it.

## Release/Deployment notes:
Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment?

After merge the following steps need to occur:

- [ ] Tag a v0.1.0 version of this repo
- [ ] Push that tag to a docker image, via `make VERSION=0.1.0 push`