### PR TITLE
Routine maintenance: Build-tools update, .github templates, tests into Makefile

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,13 @@
+## What happened (or feature request):
+
+
+## What you expected to happen:
+
+
+## How to reproduce it (as minimally and precisely as possible):
+
+
+## Anything else do we need to know:
+
+
+## Related source links or issues:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+## The Problem:
+
+## The Fix:
+
+## The Test:
+
+## Automation Overview:
+<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->
+
+## Related Issue Link(s):
+
+## Release/Deployment notes:
+<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->
+

--- a/Makefile
+++ b/Makefile
@@ -37,3 +37,9 @@ include build-tools/makefile_components/base_container.mak
 include build-tools/makefile_components/base_push.mak
 #include build-tools/makefile_components/base_test_go.mak
 include build-tools/makefile_components/base_test_python.mak
+
+test: container
+	@docker stop nginx-proxy-test || true
+	@docker rm nginx-proxy-test || true
+	docker run -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro --name nginx-proxy-test -d $(DOCKER_REPO):$(VERSION)
+	sleep 5 && curl -I localhost | grep 503  # Make sure we get a 503 from nginx by default

--- a/build-tools/makefile_components/base_build_go.mak
+++ b/build-tools/makefile_components/base_build_go.mak
@@ -31,9 +31,7 @@ linux darwin: $(GOFILES)
 	@echo "building $@ from $(SRC_AND_UNDER)"
 	@rm -f VERSION.txt
 	@mkdir -p bin/$@ .go/std/$@ .go/bin .go/src/$(PKG)
-	docker run                                                            \
-	    -t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/$@:/go/bin                                     \
@@ -44,7 +42,7 @@ linux darwin: $(GOFILES)
 	    $(BUILD_IMAGE)                    \
 	    /bin/sh -c '                      \
 	        GOOS=$@                       \
-	        go install -installsuffix 'static' -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
+	        go install -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)  \
 	    '
 	@touch $@
 	@echo $(VERSION) >VERSION.txt
@@ -53,9 +51,7 @@ static: govendor gofmt govet lint
 
 govendor:
 	@echo -n "Using govendor to check for missing dependencies and unused dependencies: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -64,9 +60,7 @@ govendor:
 
 gofmt:
 	@echo "Checking gofmt: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                    \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -75,9 +69,7 @@ gofmt:
 
 govet:
 	@echo -n "Checking go vet: "
-	docker run                                                            \
-		-t                                                                \
-		-u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                         \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \
@@ -86,9 +78,7 @@ govet:
 
 golint:
 	@echo -n "Checking golint: "
-	docker run                                                            \
-		-t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	docker run -t --rm -u $(shell id -u):$(shell id -g)                   \
 		-v $$(pwd)/.go:/go                                                 \
 		-v $$(pwd):/go/src/$(PKG)                                          \
 		-w /go/src/$(PKG)                                                  \

--- a/build-tools/makefile_components/base_container.mak
+++ b/build-tools/makefile_components/base_container.mak
@@ -12,7 +12,7 @@ container: linux .container-$(DOTFILE_IMAGE) container-name
 
 .container-$(DOTFILE_IMAGE): linux Dockerfile.in
 	@sed -e 's|UPSTREAM_REPO|$(UPSTREAM_REPO)|g' Dockerfile.in > .dockerfile
-	@echo "\n\n$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
+	@echo "$(DOCKER_REPO):$(VERSION) commit=$(shell git describe --tags --always)"  >.docker_image
 	@echo "ADD .docker_image /$(SANITIZED_DOCKER_REPO)_VERSION_INFO.txt" >>.dockerfile
 	docker build -t $(DOCKER_REPO):$(VERSION) $(DOCKER_ARGS) -f .dockerfile .
 	@docker images -q $(DOCKER_REPO):$(VERSION) > $@

--- a/build-tools/makefile_components/base_test_go.mak
+++ b/build-tools/makefile_components/base_test_go.mak
@@ -9,9 +9,7 @@ TESTOS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 test: build
 	@mkdir -p bin/linux
 	@mkdir -p .go/src/$(PKG) .go/pkg .go/bin .go/std/linux
-	@docker run                                                            \
-	    -t                                                                \
-	    -u $(shell id -u):$(shell id -g)                                             \
+	@docker run -t --rm  -u $(shell id -u):$(shell id -g)                 \
 	    -v $$(pwd)/.go:/go                                                 \
 	    -v $$(pwd):/go/src/$(PKG)                                          \
 	    -v $$(pwd)/bin/linux:/go/bin                                     \
@@ -20,6 +18,6 @@ test: build
 	    -w /go/src/$(PKG)                                                  \
 	    $(BUILD_IMAGE)                                                     \
 	    /bin/bash -c '                                                    \
-	        GOOS=`uname -s |  tr '[:upper:]' '[:lower:]'`  &&		\
-	        go test -v -installsuffix "static" -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
+	        GOOS=`uname -s |  tr "[:upper:]" "[:lower:]"`  &&		\
+	        go test -v -installsuffix static -ldflags "$(LDFLAGS)" $(SRC_AND_UNDER)   \
 	    '

--- a/circle.yml
+++ b/circle.yml
@@ -5,5 +5,4 @@ machine:
 test:
     override:
         - make container
-        - docker run -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro -d $(sed 's/^.*drud/drud/' < .docker_image | sed 's/ .*$//')
-        - curl -I localhost | grep 503  # Make sure we get a 503 from nginx by default
+        - make test


### PR DESCRIPTION
## The Problem:

Routine maintenance for the repo:
* Update build-tools to 1.0.6
* Add .github templates
* Move (trivial) tests from circle.yml into Makefile

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

[Create master build for ddev (106)](https://github.com/drud/ddev/issues/106)

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

There's probably no need to tag a new version, although it would do no harm. There are no functionality changes here.
