### PR TITLE
Mysql proxy

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -2,7 +2,9 @@ FROM UPSTREAM_REPO
 
 RUN { \
       echo 'client_max_body_size 100m;'; \
-    } > /etc/nginx/conf.d/drud.conf
+    } > /etc/nginx/conf.d/drud.conf \
+    && echo "include /etc/nginx/conf.d/tcp/*.conf;" >> /etc/nginx/nginx.conf
+RUN  mkdir -p /etc/nginx/conf.d/tcp/
 
-ADD nginx.tmpl /app/nginx.tmpl
+ADD . /app/
 

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+nginx: nginx
+dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+dockergen: docker-gen -watch -only-exposed -notify "nginx -s reload" /app/nginx.tcp.tmpl /etc/nginx/conf.d/tcp/default.conf

--- a/nginx.tcp.tmpl
+++ b/nginx.tcp.tmpl
@@ -27,15 +27,15 @@
 
     upstream {{ $hostname }} {
     {{ range $container := $containers }}
-    	{{ $addrLen := len $container.Addresses }}
+      {{ $addrLen := len $container.Addresses }}
       {{ range $knownNetwork := $CurrentContainer.Networks }}
         {{ range $containerNetwork := $container.Networks }}
           {{ if eq $knownNetwork.Name $containerNetwork.Name }}
             {{ $port := index $ports 1 }}
             {{ $address := index $container.Addresses 0 }}
             {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-        	{{ end }}
-			  {{ end }}
+          {{ end }}
+        {{ end }}
       {{ end }}
     {{ end }}
     }

--- a/nginx.tcp.tmpl
+++ b/nginx.tcp.tmpl
@@ -1,5 +1,6 @@
-{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
+{{/* This is heavily influenced by the work of GitHub user jmparra which can be found at https://github.com/jmparra/nginx-proxy/commit/b3977a8f335dda0a3285c0e435074f4e3bf423d4 */}}
 
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
 
 {{ define "upstream" }}
    {{ if .Address }}

--- a/nginx.tcp.tmpl
+++ b/nginx.tcp.tmpl
@@ -1,0 +1,48 @@
+{{ $CurrentContainer := where $ "ID" .Docker.CurrentContainerID | first }}
+
+
+{{ define "upstream" }}
+   {{ if .Address }}
+     {{/* If we got the containers from swarm and this container's port is published to host, use host IP:PORT */}}
+     {{ if and .Container.Node.ID .Address.HostPort }}
+       # {{ .Container.Node.Name }}/{{ .Container.Name }}
+       server {{ .Container.Node.Address.IP }}:{{ .Address.HostPort }};
+     {{/* If there is no swarm node or the port is not published on host, use container's IP:PORT */}}
+     {{ else }}
+       # {{ .Container.Name }}
+       server {{ .Network.IP }}:{{ .Address.Port }};
+     {{ end }}
+   {{ else }}
+     # {{ .Container.Name }}
+     server {{ .Network.IP }} down;
+   {{ end }}
+ {{ end }}
+
+ stream {
+    {{ range $ports, $containers := groupByMulti $ "Env.TCP_PORT" "," }}
+    {{ $ports := split $ports ":" }}
+    {{ $hostname := index $ports 0 }}
+    {{ $host_port := index $ports 1 }}
+
+    upstream {{ $hostname }} {
+    {{ range $container := $containers }}
+    	{{ $addrLen := len $container.Addresses }}
+      {{ range $knownNetwork := $CurrentContainer.Networks }}
+        {{ range $containerNetwork := $container.Networks }}
+          {{ if eq $knownNetwork.Name $containerNetwork.Name }}
+            {{ $port := index $ports 1 }}
+            {{ $address := index $container.Addresses 0 }}
+            {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+        	{{ end }}
+			  {{ end }}
+      {{ end }}
+    {{ end }}
+    }
+
+    server {
+      listen {{ $host_port }};
+      proxy_pass {{ $hostname }};
+    }
+
+    {{ end }}
+ }


### PR DESCRIPTION
## The Problem:
In order to maintain consistent hostnames for the MySQL container both within the web container and the host system, we need to proxy traffic on the `[sitename].ddev.local` URL through the proxy.

## The Fix:
Since we already use [docker-gen](https://github.com/jwilder/docker-gen), this just adds an additional templating option which creates a tcp stream configuration in nginx.  

To add an additional TCP stream for any service, simply define an env var on the container you would like to stream to in the form of "TCP_HOST=[hostname]:[port]"

## Related Issue Link(s):
drud/ddev#116

## Release/Deployment notes:
- [ ] Roll a new version of this container
- [ ] Update drud/ddev to use the new version of this container
- [ ] Add the required environment variable on the docker-compose manifest being used by drud/ddev

