### PR TITLE
Move testing port to 1082

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ include build-tools/makefile_components/base_push.mak
 include build-tools/makefile_components/base_test_python.mak
 
 test: container
-	@docker stop nginx-proxy-test || true
-	@docker rm nginx-proxy-test || true
-	docker run -p 80:80 -v /var/run/docker.sock:/tmp/docker.sock:ro --name nginx-proxy-test -d $(DOCKER_REPO):$(VERSION)
-	sleep 5 && curl -I localhost | grep 503  # Make sure we get a 503 from nginx by default
+	@docker stop nginx-proxy-test 2>/dev/null || true
+	@docker rm nginx-proxy-test 2>/dev/null || true
+	docker run -p 1082:80 -v /var/run/docker.sock:/tmp/docker.sock:ro --name nginx-proxy-test -d $(DOCKER_REPO):$(VERSION)
+	sleep 5 && curl -s -I localhost:1082 | grep 503  # Make sure we get a 503 from nginx by default
+	@docker stop nginx-proxy-test 


### PR DESCRIPTION
## The Problem:

The use of port 80 for testing can be problematic on local workstation, so move it off to 1082.

## The Fix:

## The Test:

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

