### PR TITLE
Provide support for custom listen ports

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -78,15 +78,15 @@ server {
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
-upstream {{ $host }} {
 {{ range $container := $containers }}
+{{ $add_port := coalesce $container.Env.VIRTUAL_PORT_ADD "" }}
+upstream {{ $host }} {
 	{{ $addrLen := len $container.Addresses }}
 
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
 		{{ range $containerNetwork := $container.Networks }}
 			{{ if eq $knownNetwork.Name $containerNetwork.Name }}
 				## Can be connect with "{{ $containerNetwork.Name }}" network
-
 				{{/* If only 1 port exposed, use that */}}
 				{{ if eq $addrLen 1 }}
 					{{ $address := index $container.Addresses 0 }}
@@ -97,36 +97,17 @@ upstream {{ $host }} {
 					{{ $address := where $container.Addresses "Port" $port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{ end }}
-			{{ end }}
-		{{ end }}
-	{{ end }}
-{{ end }}
 }
-
-upstream {{ $host }}-mailhog {
-{{ range $container := $containers }}
-	{{ $addrLen := len $container.Addresses }}
-
-	{{ range $knownNetwork := $CurrentContainer.Networks }}
-		{{ range $containerNetwork := $container.Networks }}
-			{{ if eq $knownNetwork.Name $containerNetwork.Name }}
-				## Can be connect with "{{ $containerNetwork.Name }}" network
-
-				{{/* If only 1 port exposed, use that */}}
-				{{ if eq $addrLen 1 }}
-					{{ $address := index $container.Addresses 0 }}
+				{{ if $add_port }}
+				upstream {{ $host }}-{{ $add_port }} {
+					{{ $address := where $container.Addresses "Port" $add_port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
-				{{ else }}
-					{{ $port := "8025" }}
-					{{ $address := where $container.Addresses "Port" $port | first }}
-					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+				}
 				{{ end }}
 			{{ end }}
 		{{ end }}
 	{{ end }}
 {{ end }}
-}
 
 
 {{ $default_host := or ($.Env.DEFAULT_HOST) "" }}
@@ -153,9 +134,13 @@ upstream {{ $host }}-mailhog {
 
 {{ $is_https := (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
+{{/* Get the VIRTUAL_PORT_ADD defined by containers w/ the same vhost, falling back to "" */}}
+{{ $add_port := or (first (groupByKeys $containers "Env.VIRTUAL_PORT_ADD")) "" }}
+
+{{ if $add_port }}
 server {
 	server_name {{ $host }};
-	listen 8025 {{ $default_server }};
+	listen {{ $add_port }} {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
@@ -167,9 +152,9 @@ server {
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $host }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $host }}-{{ trim $add_port }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $host }}-mailhog;
+		proxy_pass {{ trim $proto }}://{{ trim $host }}-{{ trim $add_port }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
@@ -182,6 +167,7 @@ server {
                 {{ end }}
 	}
 }
+{{ end }}
 
 {{ if $is_https }}
 

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -78,9 +78,18 @@ server {
 
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
 
+{{/* If host is defined as hostname:port, port will be used as the listen port instead of 80 */}}
+{{ $host_port := split $host ":" }}
+{{ $hostname := first $host_port }}
+{{ $ext_port := last $host_port }}
+{{/* if hostname and ext_port match, there was no ":", so fallback to port 80 */}}
+{{ $ext_port := when (eq $hostname $ext_port) "80" $ext_port}}
+{{ $host := $hostname }}
+
 {{ range $container := $containers }}
 {{ $add_port := coalesce $container.Env.VIRTUAL_PORT_ADD "" }}
-upstream {{ $host }} {
+
+upstream {{ $container.Name }} {
 	{{ $addrLen := len $container.Addresses }}
 
 	{{ range $knownNetwork := $CurrentContainer.Networks }}
@@ -97,9 +106,9 @@ upstream {{ $host }} {
 					{{ $address := where $container.Addresses "Port" $port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				{{ end }}
-}
+} {{/* end of upstream started on 92 */}}
 				{{ if $add_port }}
-				upstream {{ $host }}-{{ $add_port }} {
+				upstream {{ $container.Name }}-{{ $add_port }} {
 					{{ $address := where $container.Addresses "Port" $add_port | first }}
 					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 				}
@@ -137,6 +146,9 @@ upstream {{ $host }} {
 {{/* Get the VIRTUAL_PORT_ADD defined by containers w/ the same vhost, falling back to "" */}}
 {{ $add_port := or (first (groupByKeys $containers "Env.VIRTUAL_PORT_ADD")) "" }}
 
+{{/* Get the container name defined by containers w/ the same vhost */}}
+{{ $containerName := (first (groupByKeys $containers "Name")) }}
+
 {{ if $add_port }}
 server {
 	server_name {{ $host }};
@@ -152,9 +164,9 @@ server {
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $host }}-{{ trim $add_port }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $add_port }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $host }}-{{ trim $add_port }};
+		proxy_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $add_port }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
@@ -213,9 +225,9 @@ server {
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $host }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		proxy_pass {{ trim $proto }}://{{ trim $containerName }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";
@@ -235,7 +247,7 @@ server {
 
 server {
 	server_name {{ $host }};
-	listen 80 {{ $default_server }};
+	listen {{ $ext_port }} {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
@@ -247,9 +259,9 @@ server {
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $host }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $host }};
+		proxy_pass {{ trim $proto }}://{{ trim $containerName }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -87,31 +87,27 @@ server {
 {{ $host := $hostname }}
 
 {{ range $container := $containers }}
-{{ $add_port := coalesce $container.Env.VIRTUAL_PORT_ADD "" }}
+	{{ $ports := coalesce $container.Env.VIRTUAL_PORT "80" }}
+	{{ $ports := split $ports "," }}
+	{{ range $port := $ports }}
 
-upstream {{ $container.Name }} {
-	{{ $addrLen := len $container.Addresses }}
+	upstream {{ $container.Name }}-{{ $port }} {
+		{{ $addrLen := len $container.Addresses }}
 
-	{{ range $knownNetwork := $CurrentContainer.Networks }}
-		{{ range $containerNetwork := $container.Networks }}
-			{{ if eq $knownNetwork.Name $containerNetwork.Name }}
-				## Can be connect with "{{ $containerNetwork.Name }}" network
-				{{/* If only 1 port exposed, use that */}}
-				{{ if eq $addrLen 1 }}
-					{{ $address := index $container.Addresses 0 }}
-					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-				{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
-				{{ else }}
-					{{ $port := coalesce $container.Env.VIRTUAL_PORT "80" }}
-					{{ $address := where $container.Addresses "Port" $port | first }}
-					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-				{{ end }}
-} {{/* end of upstream started on 92 */}}
-				{{ if $add_port }}
-				upstream {{ $container.Name }}-{{ $add_port }} {
-					{{ $address := where $container.Addresses "Port" $add_port | first }}
-					{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-				}
+		{{ range $knownNetwork := $CurrentContainer.Networks }}
+			{{ range $containerNetwork := $container.Networks }}
+				{{ if eq $knownNetwork.Name $containerNetwork.Name }}
+					## Can be connect with "{{ $containerNetwork.Name }}" network
+					{{/* If only 1 port exposed, use that */}}
+					{{ if eq $addrLen 1 }}
+						{{ $address := index $container.Addresses 0 }}
+						{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+					{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+					{{ else }}
+						{{ $address := where $container.Addresses "Port" $port | first }}
+						{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
+					{{ end }}
+	}
 				{{ end }}
 			{{ end }}
 		{{ end }}
@@ -143,16 +139,16 @@ upstream {{ $container.Name }} {
 
 {{ $is_https := (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
-{{/* Get the VIRTUAL_PORT_ADD defined by containers w/ the same vhost, falling back to "" */}}
-{{ $add_port := or (first (groupByKeys $containers "Env.VIRTUAL_PORT_ADD")) "" }}
-
 {{/* Get the container name defined by containers w/ the same vhost */}}
 {{ $containerName := (first (groupByKeys $containers "Name")) }}
 
-{{ if $add_port }}
+{{/* Get the VIRTUAL_PORT defined by containers w/ the same vhost, falling back to port 80 */}}
+{{ $ports := or (first (groupByKeys $containers "Env.VIRTUAL_PORT")) "80" }}
+{{ $ports := split $ports "," }}
+{{ range $port := $ports }}
 server {
 	server_name {{ $host }};
-	listen {{ $add_port }} {{ $default_server }};
+	listen {{ $port }} {{ $default_server }};
 	access_log /var/log/nginx/access.log vhost;
 
 	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
@@ -164,9 +160,9 @@ server {
 	location / {
 		{{ if eq $proto "uwsgi" }}
 		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $add_port }};
+		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $port }};
 		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $add_port }};
+		proxy_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $port }};
 		{{ end }}
 		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 		auth_basic	"Restricted {{ $host }}";

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -140,148 +140,42 @@ server {
 {{ $is_https := (and (ne $cert "") (exists (printf "/etc/nginx/certs/%s.crt" $cert)) (exists (printf "/etc/nginx/certs/%s.key" $cert))) }}
 
 {{/* Get the container name defined by containers w/ the same vhost */}}
-{{ $containerName := (first (groupByKeys $containers "Name")) }}
+{{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
+	{{ range $container := whereExist $containers "Env.VIRTUAL_PORT" }}
+		{{/* Get the VIRTUAL_PORT defined by containers w/ the same vhost, falling back to port 80 */}}
+		{{ $ports := coalesce $container.Env.VIRTUAL_PORT "80" }}
+		{{ $ports := split $ports "," }}
+		{{ range $port := $ports }}
+		server {
+			server_name {{ $host }};
+			listen {{ $port }} {{ $default_server }};
+			access_log /var/log/nginx/access.log vhost;
 
-{{/* Get the VIRTUAL_PORT defined by containers w/ the same vhost, falling back to port 80 */}}
-{{ $ports := or (first (groupByKeys $containers "Env.VIRTUAL_PORT")) "80" }}
-{{ $ports := split $ports "," }}
-{{ range $port := $ports }}
-server {
-	server_name {{ $host }};
-	listen {{ $port }} {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
+			{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
+			include {{ printf "/etc/nginx/vhost.d/%s" $host }};
+			{{ else if (exists "/etc/nginx/vhost.d/default") }}
+			include /etc/nginx/vhost.d/default;
+			{{ end }}
 
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
-	{{ else if (exists "/etc/nginx/vhost.d/default") }}
-	include /etc/nginx/vhost.d/default;
+			location / {
+				{{ if eq $proto "uwsgi" }}
+				include uwsgi_params;
+				uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}-{{ trim $port }};
+				{{ else }}
+				proxy_pass {{ trim $proto }}://{{ trim $container.Name }}-{{ trim $port }};
+				{{ end }}
+				{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
+				auth_basic	"Restricted {{ $host }}";
+				auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
+				{{ end }}
+						{{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
+						include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
+						{{ else if (exists "/etc/nginx/vhost.d/default_location") }}
+						include /etc/nginx/vhost.d/default_location;
+						{{ end }}
+			}
+		}
+		{{ end }}
 	{{ end }}
-
-	location / {
-		{{ if eq $proto "uwsgi" }}
-		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $port }};
-		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $containerName }}-{{ trim $port }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-                include /etc/nginx/vhost.d/default_location;
-                {{ end }}
-	}
-}
-{{ end }}
-
-{{ if $is_https }}
-
-{{ if eq $https_method "redirect" }}
-server {
-	server_name {{ $host }};
-	listen 80 {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
-	return 301 https://$host$request_uri;
-}
-{{ end }}
-
-server {
-	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
-
-	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-	ssl_ciphers 'ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-RSA-AES256-SHA256:DHE-RSA-AES256-SHA:ECDHE-ECDSA-DES-CBC3-SHA:ECDHE-RSA-DES-CBC3-SHA:EDH-RSA-DES-CBC3-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:DES-CBC3-SHA:!DSS';
-
-	ssl_prefer_server_ciphers on;
-	ssl_session_timeout 5m;
-	ssl_session_cache shared:SSL:50m;
-	ssl_session_tickets off;
-
-	ssl_certificate /etc/nginx/certs/{{ (printf "%s.crt" $cert) }};
-	ssl_certificate_key /etc/nginx/certs/{{ (printf "%s.key" $cert) }};
-
-	{{ if (exists (printf "/etc/nginx/certs/%s.dhparam.pem" $cert)) }}
-	ssl_dhparam {{ printf "/etc/nginx/certs/%s.dhparam.pem" $cert }};
-	{{ end }}
-
-	{{ if (ne $https_method "noredirect") }}
-	add_header Strict-Transport-Security "max-age=31536000";
-	{{ end }}
-
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
-	{{ else if (exists "/etc/nginx/vhost.d/default") }}
-	include /etc/nginx/vhost.d/default;
-	{{ end }}
-
-	location / {
-		{{ if eq $proto "uwsgi" }}
-		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }};
-		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $containerName }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-                include /etc/nginx/vhost.d/default_location;
-                {{ end }}
-	}
-}
-
-{{ end }}
-
-{{ if or (not $is_https) (eq $https_method "noredirect") }}
-
-server {
-	server_name {{ $host }};
-	listen {{ $ext_port }} {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
-
-	{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
-	include {{ printf "/etc/nginx/vhost.d/%s" $host }};
-	{{ else if (exists "/etc/nginx/vhost.d/default") }}
-	include /etc/nginx/vhost.d/default;
-	{{ end }}
-
-	location / {
-		{{ if eq $proto "uwsgi" }}
-		include uwsgi_params;
-		uwsgi_pass {{ trim $proto }}://{{ trim $containerName }};
-		{{ else }}
-		proxy_pass {{ trim $proto }}://{{ trim $containerName }};
-		{{ end }}
-		{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
-		auth_basic	"Restricted {{ $host }}";
-		auth_basic_user_file	{{ (printf "/etc/nginx/htpasswd/%s" $host) }};
-		{{ end }}
-                {{ if (exists (printf "/etc/nginx/vhost.d/%s_location" $host)) }}
-                include {{ printf "/etc/nginx/vhost.d/%s_location" $host}};
-                {{ else if (exists "/etc/nginx/vhost.d/default_location") }}
-                include /etc/nginx/vhost.d/default_location;
-                {{ end }}
-	}
-}
-
-{{ if (and (not $is_https) (exists "/etc/nginx/certs/default.crt") (exists "/etc/nginx/certs/default.key")) }}
-server {
-	server_name {{ $host }};
-	listen 443 ssl http2 {{ $default_server }};
-	access_log /var/log/nginx/access.log vhost;
-	return 500;
-
-	ssl_certificate /etc/nginx/certs/default.crt;
-	ssl_certificate_key /etc/nginx/certs/default.key;
-}
-{{ end }}
-
 {{ end }}
 {{ end }}


### PR DESCRIPTION
## The Problem:
The current templating assumes you will only need to provide one upstream per container to be served from standard web ports. We need to support additional upstream definitions for containers, and to support use of non-standard web ports.

## The Fix:
This PR introduces changes to the templating to support the following new usage.

### Custom listen port definition in VIRTUAL_HOST
You can now define the `VIRTUAL_HOST` env var in the format of `hostname.com` to listen on a custom port instead of the standard web ports.

### VIRTUAL_PORT
This PR also allows the existing VIRTUAL_PORT environment var to be a CSV. For instance, if you want the a container to listen on port 80 and 8025, you would set `VIRTUAL_PORT=80,8025`

## The Test:
This is used in the PR at https://github.com/drud/ddev/pull/144. The easiest way to test this, is to test that PR.

## Related Issue Link(s):

## Release/Deployment notes:
- [ ] Roll a new version of this container
- [ ] Update the PR at https://github.com/drud/ddev/pull/144 to use the new tag

