### PR TITLE
process VIRTUAL_PORT values in hostPort:containerPort format

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -90,8 +90,11 @@ server {
 	{{ $ports := coalesce $container.Env.VIRTUAL_PORT "80" }}
 	{{ $ports := split $ports "," }}
 	{{ range $port := $ports }}
+	{{/* process values in hostPort:containerPort docker format, containerPort is upstream */}}
+	{{ $container_ports := split $port ":" }}
+	{{ $upstream_port := last $container_ports }}
 
-	upstream {{ $container.Name }}-{{ $port }} {
+	upstream {{ $container.Name }}-{{ $upstream_port }} {
 		{{ $addrLen := len $container.Addresses }}
 
 		{{ range $knownNetwork := $CurrentContainer.Networks }}
@@ -104,7 +107,7 @@ server {
 						{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 					{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
 					{{ else }}
-						{{ $address := where $container.Addresses "Port" $port | first }}
+						{{ $address := where $container.Addresses "Port" $upstream_port | first }}
 						{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
 					{{ end }}
 	}
@@ -146,9 +149,15 @@ server {
 		{{ $ports := coalesce $container.Env.VIRTUAL_PORT "80" }}
 		{{ $ports := split $ports "," }}
 		{{ range $port := $ports }}
+		{{/* process values in hostPort:containerPort docker format */}}
+		{{ $container_ports := split $port ":" }}
+		{{/* hostPort is port to listen on */}}
+		{{ $listen_port := first $container_ports }}
+		{{/* containerPort is upstream */}}
+		{{ $upstream_port := last $container_ports }}
 		server {
 			server_name {{ $host }};
-			listen {{ $port }} {{ $default_server }};
+			listen {{ $listen_port }} {{ $default_server }};
 			access_log /var/log/nginx/access.log vhost;
 
 			{{ if (exists (printf "/etc/nginx/vhost.d/%s" $host)) }}
@@ -160,9 +169,9 @@ server {
 			location / {
 				{{ if eq $proto "uwsgi" }}
 				include uwsgi_params;
-				uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}-{{ trim $port }};
+				uwsgi_pass {{ trim $proto }}://{{ trim $container.Name }}-{{ trim $upstream_port }};
 				{{ else }}
-				proxy_pass {{ trim $proto }}://{{ trim $container.Name }}-{{ trim $port }};
+				proxy_pass {{ trim $proto }}://{{ trim $container.Name }}-{{ trim $upstream_port }};
 				{{ end }}
 				{{ if (exists (printf "/etc/nginx/htpasswd/%s" $host)) }}
 				auth_basic	"Restricted {{ $host }}";


### PR DESCRIPTION
## The Problem:
We would like to support ports being defined in the VIRTUAL_PORT env var in the format of hostPort:containerPort, so that a container's port can be exposed on a different port if desired.

## The Fix:
This PR updates the router templating to process values in such a format, using containerPort to define the upstream, and hostPort to define the port to listen on in the server block definition.

## The Test:
This is easiest to test as part of testing drud/ddev#210. A simple way to test is to update the VIRTUAL_PORT definition on the web container to `VIRTUAL_PORT=80,8050:8025`. This should make mailhog available at port 8050 instead of its default 8025 port.

## Related Issue Link(s):
drud/ddev#210
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

