### PR TITLE
rename VIRTUAL_PORT->HTTP_EXPOSE and TCP_PORT->TCP_EXPOSE in host:container format

### DIFF
--- a/nginx.tcp.tmpl
+++ b/nginx.tcp.tmpl
@@ -20,7 +20,7 @@
  {{ end }}
 
  stream {
-    {{ range $ports, $containers := groupByMulti $ "Env.TCP_PORT" "," }}
+    {{ range $ports, $containers := groupByMulti $ "Env.TCP_EXPOSE" "," }}
     {{ $ports := split $ports ":" }}
     {{ $upstream_port := last $ports }}
     {{ $listen_port := first $ports }}

--- a/nginx.tcp.tmpl
+++ b/nginx.tcp.tmpl
@@ -22,16 +22,16 @@
  stream {
     {{ range $ports, $containers := groupByMulti $ "Env.TCP_PORT" "," }}
     {{ $ports := split $ports ":" }}
-    {{ $hostname := index $ports 0 }}
-    {{ $host_port := index $ports 1 }}
+    {{ $upstream_port := last $ports }}
+    {{ $listen_port := first $ports }}
 
-    upstream {{ $hostname }} {
+    upstream tcp-{{ $listen_port }} {
     {{ range $container := $containers }}
       {{ $addrLen := len $container.Addresses }}
       {{ range $knownNetwork := $CurrentContainer.Networks }}
         {{ range $containerNetwork := $container.Networks }}
           {{ if eq $knownNetwork.Name $containerNetwork.Name }}
-            {{ $port := index $ports 1 }}
+            {{ $port := $upstream_port }}
             {{ $address := index $container.Addresses 0 }}
             {{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
           {{ end }}
@@ -41,8 +41,8 @@
     }
 
     server {
-      listen {{ $host_port }};
-      proxy_pass {{ $hostname }};
+      listen {{ $listen_port }};
+      proxy_pass tcp-{{ $listen_port }};
     }
 
     {{ end }}

--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -87,7 +87,7 @@ server {
 {{ $host := $hostname }}
 
 {{ range $container := $containers }}
-	{{ $ports := coalesce $container.Env.VIRTUAL_PORT "80" }}
+	{{ $ports := coalesce $container.Env.HTTP_EXPOSE "80" }}
 	{{ $ports := split $ports "," }}
 	{{ range $port := $ports }}
 	{{/* process values in hostPort:containerPort docker format, containerPort is upstream */}}
@@ -105,7 +105,7 @@ server {
 					{{ if eq $addrLen 1 }}
 						{{ $address := index $container.Addresses 0 }}
 						{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
-					{{/* If more than one port exposed, use the one matching VIRTUAL_PORT env var, falling back to standard web port 80 */}}
+					{{/* If more than one port exposed, use the one matching HTTP_EXPOSE env var, falling back to standard web port 80 */}}
 					{{ else }}
 						{{ $address := where $container.Addresses "Port" $upstream_port | first }}
 						{{ template "upstream" (dict "Container" $container "Address" $address "Network" $containerNetwork) }}
@@ -144,9 +144,9 @@ server {
 
 {{/* Get the container name defined by containers w/ the same vhost */}}
 {{ range $host, $containers := groupByMulti $ "Env.VIRTUAL_HOST" "," }}
-	{{ range $container := whereExist $containers "Env.VIRTUAL_PORT" }}
-		{{/* Get the VIRTUAL_PORT defined by containers w/ the same vhost, falling back to port 80 */}}
-		{{ $ports := coalesce $container.Env.VIRTUAL_PORT "80" }}
+	{{ range $container := whereExist $containers "Env.HTTP_EXPOSE" }}
+		{{/* Get the HTTP_EXPOSE defined by containers w/ the same vhost, falling back to port 80 */}}
+		{{ $ports := coalesce $container.Env.HTTP_EXPOSE "80" }}
 		{{ $ports := split $ports "," }}
 		{{ range $port := $ports }}
 		{{/* process values in hostPort:containerPort docker format */}}


### PR DESCRIPTION
## The Problem:
VIRTUAL_PORT and TCP_PORT address similar concerns, but are currently defined in different ways. VIRTUAL_PORT accepts comma-separated values in hostPort:containerPort format, while TCP_PORT accepts comma-separated values in hostName:hostPort format.

## The Fix:
* Rename VIRTUAL_PORT->HTTP_EXPOSE and TCP_PORT to TCP_EXPOSE. (HTTP_EXPOSE exposes an http-proxied port on the host; TCP_EXPOSE exposes a straight TCP-proxied port on the host.)
* Updates so that TCP_EXPOSE (formerly TCP_PORT) can be defined as `hostPort:containerPort` like HTTP_EXPOSE. This allows for users to define both ports the same way, and allows for ddev to process both env vars the same way.

## The Test:
This can be tested with drud/ddev#210. Since the v0.4.0 tag has not been merged yet, I have updated that tag with these changes.

## Automation Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):
drud/ddev#210
## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->

